### PR TITLE
Added Table in Readme to display Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@
 
 <br />
 
+## Statistics 📊  
+
+| Statistic               | Count | Link                             |  
+|-------------------------|-------|----------------------------------|  
+| ![Stars](https://img.shields.io/github/stars/YOUR_USERNAME/ElectroKart?style=social) | ![Stars Count](https://img.shields.io/badge/stars-1234-yellow) | [View Stars](https://github.com/YOUR_USERNAME/ElectroKart/stargazers) |  
+| ![Forks](https://img.shields.io/github/forks/YOUR_USERNAME/ElectroKart?style=social) | ![Forks Count](https://img.shields.io/badge/forks-5678-blue) | [View Forks](https://github.com/YOUR_USERNAME/ElectroKart/network) |  
+| ![Open Issues](https://img.shields.io/github/issues/YOUR_USERNAME/ElectroKart) | ![Open Issues Count](https://img.shields.io/badge/issues-90-red) | [View Issues](https://github.com/YOUR_USERNAME/ElectroKart/issues) |  
+| ![Open Pull Requests](https://img.shields.io/github/issues-pr/YOUR_USERNAME/ElectroKart) | ![Open PRs Count](https://img.shields.io/badge/pull%20requests-10-orange) | [View PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls) |  
+| ![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/YOUR_USERNAME/ElectroKart) | ![Closed PRs Count](https://img.shields.io/badge/closed%20pr-50-green) | [View Closed PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls?q=is%3Apr+is%3Aclosed) |
+
 ## Table of Contents
 
 1. [Project Overview](#1-project-overview)

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
 
 | Statistic               | Count | Link                             |  
 |-------------------------|-------|----------------------------------|  
-| ![Stars](https://img.shields.io/github/stars/YOUR_USERNAME/ElectroKart?style=social) | ![Stars Count](https://img.shields.io/badge/stars-1234-yellow) | [View Stars](https://github.com/YOUR_USERNAME/ElectroKart/stargazers) |  
-| ![Forks](https://img.shields.io/github/forks/YOUR_USERNAME/ElectroKart?style=social) | ![Forks Count](https://img.shields.io/badge/forks-5678-blue) | [View Forks](https://github.com/YOUR_USERNAME/ElectroKart/network) |  
-| ![Open Issues](https://img.shields.io/github/issues/YOUR_USERNAME/ElectroKart) | ![Open Issues Count](https://img.shields.io/badge/issues-90-red) | [View Issues](https://github.com/YOUR_USERNAME/ElectroKart/issues) |  
-| ![Open Pull Requests](https://img.shields.io/github/issues-pr/YOUR_USERNAME/ElectroKart) | ![Open PRs Count](https://img.shields.io/badge/pull%20requests-10-orange) | [View PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls) |  
-| ![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/YOUR_USERNAME/ElectroKart) | ![Closed PRs Count](https://img.shields.io/badge/closed%20pr-50-green) | [View Closed PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls?q=is%3Apr+is%3Aclosed) |
+| ![Stars](https://img.shields.io/github/stars/soham0005/ElectroKart?style=social) | ![Stars Count](https://img.shields.io/badge/stars-1234-yellow) | [View Stars](https://github.com/YOUR_USERNAME/ElectroKart/stargazers) |  
+| ![Forks](https://img.shields.io/github/forks/soham0005/ElectroKart?style=social) | ![Forks Count](https://img.shields.io/badge/forks-5678-blue) | [View Forks](https://github.com/YOUR_USERNAME/ElectroKart/network) |  
+| ![Open Issues](https://img.shields.io/github/issues/soham0005/ElectroKart) | ![Open Issues Count](https://img.shields.io/badge/issues-90-red) | [View Issues](https://github.com/YOUR_USERNAME/ElectroKart/issues) |  
+| ![Open Pull Requests](https://img.shields.io/github/issues-pr/soham0005/ElectroKart) | ![Open PRs Count](https://img.shields.io/badge/pull%20requests-10-orange) | [View PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls) |  
+| ![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/soham0005/ElectroKart) | ![Closed PRs Count](https://img.shields.io/badge/closed%20pr-50-green) | [View Closed PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls?q=is%3Apr+is%3Aclosed) |
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
 
 | Statistic               | Count | Link                             |  
 |-------------------------|-------|----------------------------------|  
-| ![Stars](https://img.shields.io/github/stars/soham0005/ElectroKart?style=social) | ![Stars Count](https://img.shields.io/badge/stars-1234-yellow) | [View Stars](https://github.com/YOUR_USERNAME/ElectroKart/stargazers) |  
-| ![Forks](https://img.shields.io/github/forks/soham0005/ElectroKart?style=social) | ![Forks Count](https://img.shields.io/badge/forks-5678-blue) | [View Forks](https://github.com/YOUR_USERNAME/ElectroKart/network) |  
-| ![Open Issues](https://img.shields.io/github/issues/soham0005/ElectroKart) | ![Open Issues Count](https://img.shields.io/badge/issues-90-red) | [View Issues](https://github.com/YOUR_USERNAME/ElectroKart/issues) |  
-| ![Open Pull Requests](https://img.shields.io/github/issues-pr/soham0005/ElectroKart) | ![Open PRs Count](https://img.shields.io/badge/pull%20requests-10-orange) | [View PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls) |  
-| ![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/soham0005/ElectroKart) | ![Closed PRs Count](https://img.shields.io/badge/closed%20pr-50-green) | [View Closed PRs](https://github.com/YOUR_USERNAME/ElectroKart/pulls?q=is%3Apr+is%3Aclosed) |
+| ![Stars](https://img.shields.io/github/stars/soham0005/ElectroKart?style=social) | ![Stars Count](https://img.shields.io/badge/stars-1234-yellow) | [View Stars](https://github.com/soham0005/ElectroKart/stargazers) |  
+| ![Forks](https://img.shields.io/github/forks/soham0005/ElectroKart?style=social) | ![Forks Count](https://img.shields.io/badge/forks-5678-blue) | [View Forks](https://github.com/soham0005/ElectroKart/network) |  
+| ![Open Issues](https://img.shields.io/github/issues/soham0005/ElectroKart) | ![Open Issues Count](https://img.shields.io/badge/issues-90-red) | [View Issues](https://github.com/soham0005/ElectroKart/issues) |  
+| ![Open Pull Requests](https://img.shields.io/github/issues-pr/soham0005/ElectroKart) | ![Open PRs Count](https://img.shields.io/badge/pull%20requests-10-orange) | [View PRs](https://github.com/soham0005/ElectroKart/pulls) |  
+| ![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/soham0005/ElectroKart) | ![Closed PRs Count](https://img.shields.io/badge/closed%20pr-50-green) | [View Closed PRs](https://github.com/soham0005/ElectroKart/pulls?q=is%3Apr+is%3Aclosed) |
 
 ## Table of Contents
 


### PR DESCRIPTION
solves issue #275 

added a well structured table to display repository statistics, such as the number of stars, forks, issues, and pull requests, directly in the README.md file. This will help contributors and users track the activity and contributions at a glance.

@soham0005 kindly review my PR and please provide the labels of level 1, gssoc extended and hacktoberfest